### PR TITLE
Fix wrong import path in Readme.md file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -264,7 +264,7 @@ package helloworld
 
 import (
 	"flamingo.me/dingo"
-	"flamingo.me/hello-flamingo/src/helloworld/interfaces"
+	"flamingo.me/example-helloworld/src/helloworld/interfaces"
 	"flamingo.me/flamingo/v3/framework/web"
 )
 


### PR DESCRIPTION
There was a wrong import path in readme file, we've fixed that.