### PR TITLE
fix: wrong method call

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -237,7 +237,7 @@ func (r *routes) Routes(registry *web.RouterRegistry) {
   registry.MustRoute("/hello", "hello")
 
   // Bind the controller.Action to the handle "hello":
-  registry.HandleGet("hello", r.helloController.Hello)
+  registry.HandleGet("hello", r.helloController.Get)
 }
 ```
 


### PR DESCRIPTION
Fixing a minor mistake in the given example within the tutorial.