### PR TITLE
Fix: Tutorial missing method Hello in *interfaces.HelloController

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -175,8 +175,8 @@ func (controller *HelloController) Inject(responder *web.Responder) *HelloContro
 	return controller
 }
 
-// Get is a controller action that renders the `hello.html` template
-func (controller *HelloController) Get(ctx context.Context, r *web.Request) web.Result {
+// Hello is a controller action that renders the `hello.html` template
+func (controller *HelloController) Hello(ctx context.Context, r *web.Request) web.Result {
 	// Calling the Render method from the response helper and render the template "hello"
 	return controller.responder.Render("hello", nil)
 }


### PR DESCRIPTION
The repo [exmpale-hellowwolrd](https://github.com/i-love-flamingo/example-helloworld/blob/master/src/helloworld/interfaces/hello_controller.go) is using **`.Hello`** as method name and [example-flamingo-carotene](https://github.com/i-love-flamingo/example-flamingo-carotene) is using **`.Get`**. Somehow the code snippet ends up with both in this tutorial, which is definitely somewhat frustrating for people getting started. 